### PR TITLE
Remove magic numbers from Mario

### DIFF
--- a/public/examples/Intermediate/Mario.elm
+++ b/public/examples/Intermediate/Mario.elm
@@ -24,14 +24,16 @@ render (w',h') mario =
                 | mario.vx /= 0 -> "walk"
                 | otherwise     -> "stand"
       src  = "/imgs/mario/" ++ verb ++ "/" ++ mario.dir ++ ".gif"
+      groundY = 40
+      marioH = 13
   in collage w' h'
       [ rect w h  |> filled (rgb 174 238 238)
-      , rect w 50 |> filled (rgb 74 163 41)
-                  |> move (0, 24 - h/2)
-      , toForm (image 35 35 src) |> move (mario.x, mario.y + 62 - h/2)
+      , rect w groundY |> filled (rgb 74 163 41)
+                  |> move (0, (groundY - h)/2)
+      , toForm (image 35 35 src) |> move (mario.x, groundY - h/2 + marioH + mario.y)
       ]
 
--- MARIO
+-- INPUT
 input = let delta = lift (\t -> t/20) (fps 25)
         in sampleOn delta (lift2 (,) delta Keyboard.arrows)
 


### PR DESCRIPTION
Replace unexplained 50, 24, 62 with semantically meaningful values. This change was inspired by the debugger - changing either of the new parameters actually makes sense in the drawing.

Also change heading to `INPUT` as described in "accidentally well-architected code".

In theory, `marioH` should be half the height of the gif, but his feet aren't on the bottom of the image. Do some cropping and that can be abstracted as well.