### PR TITLE
Fix broken links to stdlib docs

### DIFF
--- a/public/blog/Interactive-Programming.elm
+++ b/public/blog/Interactive-Programming.elm
@@ -260,7 +260,7 @@ still some open technical questions:
 
 * Even in a pure language, it is possible to associate state with functions by using
   [continuation passing style](http://en.wikipedia.org/wiki/Continuation-passing_style) (CPS).
-  This comes up in [the Automaton library](http://docs.elm-lang.org/library/Automaton.elm),
+  This comes up in [the Automaton library](http://library.elm-lang.org/catalog/evancz-automaton/latest),
   which is an alternate way to write reactive code. Is it possible to persist state *and*
   update functions when using CPS?
 

--- a/public/blog/Pong.elm
+++ b/public/blog/Pong.elm
@@ -357,7 +357,7 @@ it is specific to Arrowized FRP, which is supported by Elm&rsquo;s
 [Automaton][automaton] library.
 
  [afrp]: http://haskell.cs.yale.edu/wp-content/uploads/2011/01/yampa-arcade.pdf
- [automaton]: http://library.elm-lang.org/catalog/evancz-automaton/0.1.0.1
+ [automaton]: http://library.elm-lang.org/catalog/evancz-automaton/latest
 
 Learning by doing is a great way to improve your skills, so if you want to
 learn more about making games in Elm, try tackling some of these challenges:

--- a/public/examples/Functional/Either.elm
+++ b/public/examples/Functional/Either.elm
@@ -9,7 +9,7 @@ The result is normally held in the Right (a pun indicating
 that it is correct).
 
 More info at:
-  http://docs.elm-lang.org/library/Either.elm
+  http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Either
 
 -----------------------------------------------------------}
 

--- a/public/learn/Escape-from-Callback-Hell.elm
+++ b/public/learn/Escape-from-Callback-Hell.elm
@@ -482,7 +482,7 @@ time-sensitive [sampling][sample] and [filtering][filter], and [asynchrony][http
 This makes it much easier to deal with complicated time-dependent interactions,
 a task that is extremely common when designing user interfaces.
 
-  [signal]: http://docs.elm-lang.org/library/Signal.elm "Signal Docs"
+  [signal]: http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Signal "Signal Docs"
   [stamp]: /edit/examples/Intermediate/Stamps.elm "Stamps"
   [clock]: /edit/examples/Intermediate/Clock.elm "Clock"
   [sample]: /edit/examples/Reactive/SampleOn.elm "sampleOn"


### PR DESCRIPTION
Some pages contain broken links to the standard library docs, this patch replaces the outdated URLs.

There are a number of broken links in Elm release announcements as well,

```
$ git grep docs.elm-lang.org | wc -l
      39
```

but I didn't know which library version would be appropriate and so didn't touch those.