### PR TITLE
Update `Making Pong` for elm 0.14.0

### DIFF
--- a/frontend/public/blog/Pong.elm
+++ b/frontend/public/blog/Pong.elm
@@ -100,7 +100,7 @@ can be represented by an integer in { -1, 0, 1 }. So to represent the game
 like this:
 
 ```haskell
-type Input = { space:Bool, paddle1:Int, paddle2:Int, delta:Time }
+type alias Input = { space:Bool, paddle1:Int, paddle2:Int, delta:Time }
 ```
 
 From here we will actually define these inputs. To keep track of the passage of
@@ -122,8 +122,8 @@ all inputs.
 ```haskell
 input : Signal Input
 input = sampleOn delta <| Input <~ Keyboard.space
-                                 ~ lift .y Keyboard.wasd
-                                 ~ lift .y Keyboard.arrows
+                                 ~ Signal.map .y Keyboard.wasd
+                                 ~ Signal.map .y Keyboard.arrows
                                  ~ delta
 ```
 
@@ -147,7 +147,7 @@ about this!
 The most basic thing we need to model is the &ldquo;pong court&rdquo;. This
 just comes down to the dimensions of the court to know when the ball should
 bounce and where the paddles should stop. We will also define halfway points
-which are commonly used. 
+which are commonly used.
 
 ```haskell
 (gameWidth,gameHeight) = (600,400)
@@ -160,11 +160,11 @@ velocity, so thanks to [structural typing](/learn/Records.elm) in Elm, we can
 share some code later on.
 
 ```haskell
-type Object a = { a | x:Float, y:Float, vx:Float, vy:Float }
+type alias Object a = { a | x:Float, y:Float, vx:Float, vy:Float }
 
-type Ball = Object {}
+type alias Ball = Object {}
 
-type Player = Object { score:Int }
+type alias Player = Object { score:Int }
 ```
 
 Both `Ball` and `Player` have a position and velocity, but notice that a
@@ -184,7 +184,7 @@ to put it together. We define a `Game` that includes all of these things and
 then create a default game state.
 
 ```haskell
-type Game = { state:State, ball:Ball, player1:Player, player2:Player }
+type alias Game = { state:State, ball:Ball, player1:Player, player2:Player }
 
 player : Float -> Player
 player x = { x=x, y=0, vx=0, vy=0, score=0 }
@@ -318,7 +318,7 @@ displaying scores and instructions nicely.
 -- helper values
 pongGreen = rgb 60 100 60
 textGreen = rgb 160 200 160
-txt f = leftAligned << f << monospace << Text.color textGreen << toText
+txt f = leftAligned << f << monospace << Text.color textGreen << fromString
 msg = "SPACE to start, WS and &uarr;&darr; to move"
 
 -- shared function for rendering objects
@@ -331,8 +331,8 @@ display : (Int,Int) -> Game -> Element
 display (w,h) {state,ball,player1,player2} =
   let scores : Element
       scores = txt (Text.height 50) <|
-               show player1.score ++ "  " ++ show player2.score
-  in 
+               toString player1.score ++ "  " ++ toString player2.score
+  in
       container w h middle <|
       collage gameWidth gameHeight
        [ filled pongGreen   (rect gameWidth gameHeight)
@@ -350,7 +350,7 @@ Now that we have a way to display a particular game state, we just
 apply it to our `gameState` that changes over time.
 
 ```haskell
-main = lift2 display Window.dimensions gameState
+main = Signal.map2 display Window.dimensions gameState
 ```
 
 And that is it, [Pong in Elm](/edit/examples/Intermediate/Pong.elm)!


### PR DESCRIPTION
Hi,

I was doing the [Making Pong](http://elm-lang.org/blog/Pong.elm) tutorial the other day and had to make some changes to get it working with Elm 0.14.0.

I did the following to get it to work:
 * change `type` to `type alias`,
 * change `data` to `type`,
 * change `toText` to `fromString`
 * change `show` to `toString`
 * and change `lift` to `Signal.map`
