### PR TITLE
Add mention of  importing Text (..) to the beginner course

### DIFF
--- a/frontend/public/learn/courses/beginner/Programming.elm
+++ b/frontend/public/learn/courses/beginner/Programming.elm
@@ -73,11 +73,14 @@ for skimming or review or whatever.
 Every coder’s first program is “Hello World!”. Welcome to the club!
 
 ```haskell
+import Text (..)
+
 main = asText "Hello World!"
 ```
 
 `main` is what gets shown on screen. `asText` will turn anything
 into text that can be shown on screen.
+When you do the following steps, keep `import Text (..)` at the top of editor.
 
 
 ### Numbers


### PR DESCRIPTION
When I tried to follow the beginner demo, the online editor complained about asText. Adding the import statement fixed it.