### PR TITLE
Correct cabal version 0.18 to 1.18

### DIFF
--- a/frontend/public/Install.elm
+++ b/frontend/public/Install.elm
@@ -91,7 +91,7 @@ be on your PATH. If not, then they should be in `~/.cabal/bin` which you can
 [add-path]: http://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path
 
 **If you use Haskell for other stuff**, it would be best to use cabal
-sandboxes for the install process. These were released with cabal 0.18 and will
+sandboxes for the install process. These were released with cabal 1.18 and will
 let you use [this install script][script].
 
 [script]: https://github.com/elm-lang/elm-platform/blob/master/installers/BuildFromSource.hs#L1-L31


### PR DESCRIPTION
Sandbox install script doesn't work with 1.16 (which is what is on the ubuntu repository), so I looked it up and found it should say 1.18.