### PR TITLE
Bump Installation Directions Version Number

### DIFF
--- a/frontend/public/Install.elm
+++ b/frontend/public/Install.elm
@@ -78,7 +78,7 @@ Then run the following commands:
 ```bash
 cabal update
 cabal install cabal-install
-cabal install -j elm-compiler-0.15 elm-package-0.5 elm-make-0.1.1
+cabal install -j elm-compiler-0.15 elm-package-0.5 elm-make-0.1.2
 cabal install -j elm-repl-0.4.1 elm-reactor-0.3.1
 ```
 


### PR DESCRIPTION
The directions on the website currently say to install elm-make 0.1.1
with `cabal install`. This causes odd syntax errors to show up when
trying to compile elm-lang/core (probably the cause behind issue #218).
Therefore bumped to elm-make 0.1.2.