### PR TITLE
Syntax examples: Don't use (<|) as an user defined operator since it's builtin

### DIFF
--- a/frontend/public/learn/Syntax.elm
+++ b/frontend/public/learn/Syntax.elm
@@ -210,9 +210,13 @@ is left, but you can set your own.
 You cannot override the built-in operators though.
 
 ```haskell
-f <| x = f x
+(?) : Maybe a -> a -> a
+maybe ? default =
+    case maybe of
+      Just x -> x
+      Nothing -> default
 
-infixr 0 <|
+infixr 8 ?
 ```
 
 Use [`(<|)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#<|)

--- a/frontend/public/learn/Syntax.elm
+++ b/frontend/public/learn/Syntax.elm
@@ -211,10 +211,7 @@ You cannot override the built-in operators though.
 
 ```haskell
 (?) : Maybe a -> a -> a
-maybe ? default =
-    case maybe of
-      Just x -> x
-      Nothing -> default
+maybe ? default = Maybe.withDefault default maybe
 
 infixr 8 ?
 ```


### PR DESCRIPTION
Syntax.elm: Use different example for defining own infix operators

Hitherto `<|` is used as an user defined operator. But this is a builtin operator that can't be overwritten.
So I propose to use `?` as an infix variant of Maybe.withDefault.

Code for the function is taken from @evancz at https://groups.google.com/d/msg/elm-discuss/kgiM9j3Xrbw/EA9KSSqNkBYJ