### PR TITLE
Fix signal-graph-summary image content column overflow

### DIFF
--- a/src/guide/chapters/architecture.md
+++ b/src/guide/chapters/architecture.md
@@ -61,7 +61,7 @@ gets updated and [elm-html][] takes care of rendering the changes efficiently.
 This means values flow through an Elm program in only one direction, something
 like this:
 
-![Signal Graph Summary](/assets/diagrams/signal-graph-summary.png)
+<img src="/assets/diagrams/signal-graph-summary.png" alt="Signal Graph Summary" style="width: 100%;"/>
 
 The blue part is our core Elm program which is exactly the model/update/view
 pattern we have been discussing so far. When programming in Elm, you can


### PR DESCRIPTION
This PR fixes the width of the signal-graph-summary image that was added in #317.
I didn't have the environment running locally so I didn't notice it looked like that, sorry about that :smile: 

**Before:**
![schermafbeelding 2015-06-20 om 09 46 06](https://cloud.githubusercontent.com/assets/304603/8266492/6ab32970-1731-11e5-9af7-363bd966d75e.png)

**After:**
![schermafbeelding 2015-06-20 om 09 46 25](https://cloud.githubusercontent.com/assets/304603/8266493/6ed15234-1731-11e5-9871-d8a51606c08f.png)

