### PR TITLE
add link to get-started-page

### DIFF
--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -27,8 +27,11 @@ install = """
   * Windows &mdash; [installer](http://install.elm-lang.org/Elm-Platform-0.15.1.exe)
   * Anywhere &mdash; [npm installer][npm] (not yet updated to 0.15.1) or [build from source][build]
 
+Afterwards, visit the [get started page][get-started].
+
 [npm]: https://www.npmjs.com/package/elm
 [build]: https://github.com/elm-lang/elm-platform
+[get-started]: http://elm-lang.org/Get-Started.elm
 
 ## Syntax Highlighting
 


### PR DESCRIPTION
The link http://elm-lang.org/Get-Started.elm is currently shown at the end of the Windows and Mac install processes, but [as seen in this thread](https://groups.google.com/d/msg/elm-discuss/-JqrhSDZyn4/yVvh_H6UhMYJ), it is easily overlooked or dismissed there. So it would be better if the install page itself also mentioned it as a next thing to look at.

(Also, the npm installer does not currently provide that link, but I'll make a PR there to change that.)