### PR TITLE
Fix let example square function

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -239,7 +239,7 @@ Historical note: this is borrowed from F#, inspired by Unix pipes.
 let n = 42
     (a,b) = (3,4)
     {x,y} = { x=3, y=4 }
-    square n = n * n
+    square n = n^2
 in
     square a + square b
 ```


### PR DESCRIPTION
Reading the language guides this evening and spotted a simple bug, didn't want it to confuse others like it confused me. :smile: 