### PR TITLE
provide "source link" for Mario example

### DIFF
--- a/src/pages/home.elm
+++ b/src/pages/home.elm
@@ -151,7 +151,7 @@ examples =
       "Home/Mario"
       "/examples/short-mario"
       "evancz"
-      ""
+      "http://elm-lang.org/examples/short-mario"
   , example
       "Home/Elmtris"
       "http://people.cs.umass.edu/~jcollard/elmtris/"


### PR DESCRIPTION
Currently, the "source" link on the first example on the [homepage](http://elm-lang.org/) appears as dead, which may seem odd to visitors.