### PR TITLE
Update reference to Json.Value and fix broken link

### DIFF
--- a/src/guide/chapters/interop.md
+++ b/src/guide/chapters/interop.md
@@ -130,6 +130,6 @@ The particular types that can be sent in and out of ports is quite flexible, cov
   * **Records** &ndash; correspond to JavaScript objects
   * **Signals** &ndash; correspond to event streams in JS
   * **Maybes**  &ndash; `Nothing` and `Just 42` correspond to `null` and `42` in JS
-  * **Json**    &ndash; [`Json.Value`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json) corresponds to arbitrary JSON
+  * **Json**    &ndash; [`Json.Encode.Value`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Encode) corresponds to arbitrary JSON
 
 All conversions are symmetric and type safe. If someone tries to give a badly typed value to Elm it will throw an error in JS immediately. By having a border check like this, Elm code can continue to guarantee that you will never have type errors at runtime.


### PR DESCRIPTION
There's also Json.Decode.Value to consider.