### PR TITLE
Make Mouse.isDown example docs match how it works

### DIFF
--- a/src/examples/mouse-is-down.elm
+++ b/src/examples/mouse-is-down.elm
@@ -2,8 +2,8 @@ import Graphics.Element exposing (..)
 import Mouse
 
 
--- Mouse.isDown is true whenever the left mouse button
--- is pressed down and false otherwise.
+-- Mouse.isDown is true when any mouse button
+-- is pressed down, and false otherwise. 
 
 main : Signal Element
 main =


### PR DESCRIPTION
Until Mouse.left and Mouse.right are added as part of https://github.com/elm-lang/core/issues/43, it makes sense for the docs on examples to be true to how the function works to avoid any confusion.