### PR TITLE
Use correct README url for the example

### DIFF
--- a/src/guide/chapters/reactivity.md
+++ b/src/guide/chapters/reactivity.md
@@ -360,7 +360,7 @@ port fetchReadme =
 -- the URL of the README.md that we desire
 readmeUrl : String
 readmeUrl =
-  "https://raw.githubusercontent.com/evancz/elm-architecture-tutorial/master/README.md"
+  "https://raw.githubusercontent.com/elm-lang/core/master/README.md"
 ```
 
 The most interesting part is happening in the `fetchReadme` port. We attempt to


### PR DESCRIPTION
This PR fixes #359 , as it had a wrong URL