### PR TITLE
Change systematic to systemic

### DIFF
--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -233,7 +233,7 @@ Records in Elm are *similar* to objects in JavaScript, but there are some crucia
 - No field will ever be undefined or null.
 - You cannot create recursive records with a `this` or `self` keyword.
 
-Elm encourages a strict separation of data and logic, and the ability to say `this` is primarily used to break this separation. This is a systematic problem in Object Oriented languages that Elm is purposely avoiding.
+Elm encourages a strict separation of data and logic, and the ability to say `this` is primarily used to break this separation. This is a systemic problem in Object Oriented languages that Elm is purposely avoiding.
 
 Records also support [structural typing][st] which means records in Elm can be used in any situation as long as the necessary fields exist. This gives us flexibility without compromising reliability.
 


### PR DESCRIPTION
I believe the author intended to use the word "systemic" here rather than "systematic"

systemic adj -- of or relating to a system, especially as opposed to a particular part: the disease is localized rather than systemic.
systematic adj -- done or acting according to a fixed plan or system; methodical: a systematic search of the whole city.