### PR TITLE
Correct order of cabal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ git clone https://github.com/elm-lang/elm-lang.org.git
 cd elm-lang.org
 git checkout master
 cabal sandbox init --sandbox ../.cabal-sandbox
-cabal configure
 cabal install --only-dependencies
+cabal configure
 cabal build
 ./dist/build/run-elm-website/run-elm-website
 ```


### PR DESCRIPTION
First need to install dependencies, only then can configure the main package.