### PR TITLE
Fix the types for averageNameLength example

### DIFF
--- a/src/guide/chapters/model-the-problem.md
+++ b/src/guide/chapters/model-the-problem.md
@@ -39,7 +39,7 @@ import List exposing (sum, map, length)
 
 averageNameLength : List String -> Float
 averageNameLength names =
-  sum (map String.length names) / length names
+  toFloat (sum (map String.length names)) / toFloat (length names)
 
 
 isLong : { record | pages : Int } -> Bool


### PR DESCRIPTION
Someone on IRC and the mailing lists brought up that that the example in "Model the Problem" is wrong due to mix of Int/Float types. I've wrapped things in `toFloat` to make it work - not using `<|` to make simpler for a beginner to understand.