### PR TITLE
Mention << and >> on syntax page

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -232,6 +232,10 @@ dot' =
 
 Historical note: this is borrowed from F#, inspired by Unix pipes.
 
+Relatedly, [`(<<)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#<<)
+and [`(>>)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#>>)
+are function composition operators.
+
 
 ### Let Expressions
 


### PR DESCRIPTION
... with pointers to the documentation of `Basics` in `core`.

Directly addresses https://github.com/elm-lang/elm-lang.org/issues/333, and various equivalent questions/requests that come up again and again on the mailing list. It is true that these are "just" operators and not syntax, but it is equally true that especially newcomers are looking at them as syntax (when they encounter them in example code on the website), and are expecting to find them explained on the syntax page. I think we have seen enough evidence for this expectation, and it would be good to not ignore it.