### PR TITLE
Fix css class referenced

### DIFF
--- a/src/pages/home.elm
+++ b/src/pages/home.elm
@@ -57,7 +57,7 @@ debuggerSection =
     , p [ style [ "text-align" => "center" ] ]
         [ a [href "/examples/hello-world", style ["display" => "inline-block"]]
           [ code
-            [ class "lang-haskell hljs"
+            [ class "lang-elm hljs"
             , style [ "display" => "inline-block", "border-radius" => "16px", "padding" => "24px 48px" ]
             ]
             [ span [class "hljs-title"] [text "main"]


### PR DESCRIPTION
In [this commit](https://github.com/elm-lang/elm-lang.org/commit/790e68af01203a4f8a6dc8a15824453df52a4194), css class `lang-haskell` was replaced by `lang-elm`, so it seems wrong that the code here was still referring to `lang-haskell`. (No other references to that old class are otherwise left in the repository.)