### PR TITLE
Make <tbody> a child of <table>

### DIFF
--- a/src/pages/docs/from-javascript.elm
+++ b/src/pages/docs/from-javascript.elm
@@ -37,8 +37,8 @@ syntaxTable subtitle comparisions =
   div [Center.style "800px"]
     [ h2 [] [text subtitle]
     , div [class "comparison"]
-        [ tbody []
-            [ table [] (header :: List.map row comparisions)
+        [ table []
+            [ tbody [] (header :: List.map row comparisions)
             ]
         ]
     , br [] []


### PR DESCRIPTION
`<tbody>` is only allowed inside of `<table>`, see <http://www.w3.org/TR/html-markup/tbody.html>.

There are no styling changes needed, though now these two rules apply. <https://github.com/elm-lang/elm-lang.org/blob/fc1fe4462baeab5abf7369ce360f589ec6feb6e7/assets/style.css#L184-L189>
Should the table cells have borders? If not those rules can probably get removed.