### PR TITLE
Second example doesn't compile, String module not imported

### DIFF
--- a/src/guide/chapters/model-the-problem.md
+++ b/src/guide/chapters/model-the-problem.md
@@ -35,7 +35,7 @@ Here we are just describing the general shape of the data we are working with. `
 
 ```elm
 import List exposing (sum, map, length)
-
+import String
 
 averageNameLength : List String -> Float
 averageNameLength names =


### PR DESCRIPTION
- It lacks `import String` to use the `String.length` function

As I'm learning Elm, I simply copy-pasted the code snippet into a file, did `elm install` to make sure I have `elm-core`, then elm-make. Got this error :

```
Cannot find variable `String.length`.

6|   sum (map String.length names) / length names
              ^^^^^^^^^^^^^
The qualifier `String` is not in scope. 


Detected errors in 1 module. 
```