### PR TITLE
Fix Hot Swap

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -49,7 +49,7 @@ function hotSwap()
 					error.style.backgroundColor = 'rgba(245,245,245,0.95)';
 				}
 				error.innerHTML = '<b>Hot Swap Failed</b><br/>' +
-					result.error.replace(/\n/g, '<br/>').replace(/  /g, " &nbsp;");
+					result.error[0].details.replace(/\n/g, '<br/>').replace(/  /g, " &nbsp;");
 				top.output.document.body.appendChild(error);
 			}
 		}


### PR DESCRIPTION
Errors from Hot Swap response were never showed up cause the returned object was not the expected one.