### PR TITLE
Use bintray download links for the Mac and Windows installers

### DIFF
--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -23,8 +23,8 @@ install = """
 
 # Install
 
-  * Mac &mdash; [installer](http://install.elm-lang.org/Elm-Platform-0.15.1.pkg)
-  * Windows &mdash; [installer](http://install.elm-lang.org/Elm-Platform-0.15.1.exe)
+  * Mac &mdash; [installer](https://dl.bintray.com/elmlang/elm-platform/0.15.1/:Elm-Platform-0.15.1.pkg)
+  * Windows &mdash; [installer](https://dl.bintray.com/elmlang/elm-platform/0.15.1/:Elm-Platform-0.15.1.exe)
   * Anywhere &mdash; [build from source][build]
 
 [npm]: https://www.npmjs.com/package/elm


### PR DESCRIPTION
I added a separate Bintray repo for these. This just uses those links instead of the current `install.elm-lang.org` links.