### PR TITLE
Add Brackets syntax highlighting, consistent order

### DIFF
--- a/src/pages/get-started.elm
+++ b/src/pages/get-started.elm
@@ -138,9 +138,9 @@ We know of Elm syntax highlighting modes for at least the following text editors
   * [Atom](https://atom.io/packages/language-elm)
   * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
+  * [Light Table](https://github.com/rundis/elm-light)
   * [Sublime Text](https://github.com/deadfoxygrandpa/Elm.tmLanguage)
   * [Vim](https://github.com/lambdatoast/elm.vim)
-  * [Light Table](https://github.com/rundis/elm-light)
 
 There may be others out there. If you cannot find an Elm mode for your
 favorite editor, using Haskell syntax highlighting is close enough to be

--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -32,11 +32,12 @@ install = """
 
 ## Syntax Highlighting
 
-  * [Sublime Text](https://github.com/deadfoxygrandpa/Elm.tmLanguage)
   * [Atom](https://atom.io/packages/language-elm)
+  * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
-  * [Vim](https://github.com/lambdatoast/elm.vim)
   * [Light Table](https://github.com/rundis/elm-light)
+  * [Sublime Text](https://github.com/deadfoxygrandpa/Elm.tmLanguage)
+  * [Vim](https://github.com/lambdatoast/elm.vim)
 
 
 ## Help


### PR DESCRIPTION
The Get Started page already mentioned the Brackets syntax highlighting, and mentioned the editors in alphabetic order; the Install page didn't yet.