### PR TITLE
Changed from "elm" to "Elm"

### DIFF
--- a/src/pages/home.elm
+++ b/src/pages/home.elm
@@ -31,7 +31,7 @@ main =
 
 splash =
   div [ id "splash" ]
-    [ div [ size 100 16 ] [ text "elm" ]
+    [ div [ size 100 16 ] [ text "Elm" ]
     , div [ size 26 8 ] [ text "the best of functional programming in your browser" ]
     , div [ size 16 4 ] [ text "writing great code should be easy ... now it is" ]
     , div [ size 26 30 ]


### PR DESCRIPTION
The page title says "Elm" and also the rest of the page says "Elm" so I was wondering why on this place it is written "elm".