### PR TITLE
Bottom padding on pages

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2,12 +2,12 @@
 
 html, head, body {
   margin: 0;
-  height: 100%;
 }
 
 body {
   font-family: 'Source Sans Pro', 'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif;
   color: #293c4b;
+  padding-bottom: 50px;
 }
 
 h1, h2, h3, h4 {


### PR DESCRIPTION
Looks better to my eyes.

Try e.g. scrolling to the bottom of http://elm-lang.org/docs/style-guide or http://elm-lang.org/examples and note how the last bit of content is quite close to the edge of the viewport, without much breathing room.