### PR TITLE
Mention npm installer on install page

### DIFF
--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -25,7 +25,7 @@ install = """
 
   * Mac &mdash; [installer](http://install.elm-lang.org/Elm-Platform-0.16.pkg)
   * Windows &mdash; [installer](http://install.elm-lang.org/Elm-Platform-0.16.exe)
-  * Anywhere &mdash; [build from source][build]
+  * Anywhere &mdash; [npm installer][npm] or [build from source][build]
 
 [npm]: https://www.npmjs.com/package/elm
 [build]: https://github.com/elm-lang/elm-platform


### PR DESCRIPTION
... once that is a stable route. Is it already right now? @rtfeldman 