### PR TITLE
remove extra "import Task"

### DIFF
--- a/src/guide/chapters/reactivity.md
+++ b/src/guide/chapters/reactivity.md
@@ -202,7 +202,6 @@ work through all the new parts.
 import Graphics.Element exposing (show)
 import Task exposing (Task, andThen)
 import TaskTutorial exposing (getCurrentTime, print)
-import Task exposing (Task, andThen)
 
 
 port runner : Task x ()


### PR DESCRIPTION
Reading the guides and noticed an extra `import Task` in there.