### PR TITLE
Redirect /examples/Intermediate.elm to /examples

### DIFF
--- a/src/backend/Router.hs
+++ b/src/backend/Router.hs
@@ -171,6 +171,7 @@ redirects =
     , "Community.elm" ==> "/community"
     , "Elm.elm" ==> "/"
     , "Examples.elm" ==> "/examples"
+    , "examples/Intermediate.elm" ==> "/examples"
     , "Get-Started.elm" ==> "/get-started"
     , "Install.elm" ==> "/install"
     , "Learn.elm" ==> "/docs"


### PR DESCRIPTION
Part of fixing https://github.com/elm-lang/elm-lang.org/issues/450.