### PR TITLE
Replace /edit/examples/Intermediate/Flickr.elm link by /examples/flickr

### DIFF
--- a/src/pages/blog/announce/0.15.elm
+++ b/src/pages/blog/announce/0.15.elm
@@ -131,7 +131,7 @@ has a code base that is easier to refactor and debug!
 
 To learn more about tasks, check out [the tutorial](/learn/Tasks.elm) and then
 the [zip codes](/edit/examples/Reactive/ZipCodes.elm) and
-[flickr](/edit/examples/Intermediate/Flickr.elm) examples!
+[flickr](/examples/flickr) examples!
 
 
 ## Faster Text Rendering


### PR DESCRIPTION
Part of fixing #450.