### PR TITLE
Title case "Node.js" in docs as this is a proper noun

### DIFF
--- a/src/pages/blog/announce/repl.elm
+++ b/src/pages/blog/announce/repl.elm
@@ -23,7 +23,7 @@ is now available. Like any traditional
 it lets you interact with functions and expressions buried deep inside a
 large project with many modules.
 
-After you install [node.js](http://nodejs.org/download/),
+After you install [Node.js](http://nodejs.org/download/),
 you can install the REPL with:
 
 ```bash

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -418,7 +418,7 @@ imperative action:
 Experimental port handlers:
 
  * `favicon` sets the pages favicon
- * `stdout` logs to stdout in node.js and to console in browser
- * `stderr` logs to stderr in node.js and to console in browser
+ * `stdout` logs to stdout in Node.js and to console in browser
+ * `stderr` logs to stderr in Node.js and to console in browser
 
 """

--- a/src/pages/get-started.elm
+++ b/src/pages/get-started.elm
@@ -89,7 +89,7 @@ REPL stands for [read-eval-print-loop][repl] which lets you play with small
 Elm expressions. the [elm-repl][] can import code from your projects, so if you want
 to play around with a function buried deep inside a module, you can load it
 into the REPL and test it out. `elm-repl` eventually needs to evaluate
-JavaScript code, so for now you need to install [node.js](http://nodejs.org/)
+JavaScript code, so for now you need to install [Node.js](http://nodejs.org/)
 to use it. Since [elm-repl][] only offers a command line interface, browser related functionality
 will not work.
 


### PR DESCRIPTION
Reference: https://github.com/nodejs/node/commit/1d8c92e8b4b939a1fb64fb8f937b9be049dc6421