### PR TITLE
Update REPL header to 0.16.0 in Core Lang guide

### DIFF
--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -6,9 +6,9 @@ This section will walk you through Elm's simple core language. The aim is to bui
 To follow along [get everything installed](/install) and start up `elm repl` in the terminal. It should look like this:
 
 ```elm
-Elm REPL 0.4.1 (Elm Platform 0.15)
-  See usage examples at <https://github.com/elm-lang/elm-repl>
-  Type :help for help, :exit to exit
+---- elm repl 0.16.0 -----------------------------------------------------------
+ :help for help, :exit to exit, more at <https://github.com/elm-lang/elm-repl>
+--------------------------------------------------------------------------------
 >
 ```
 


### PR DESCRIPTION
Building off #505's feedback, this PR updates the REPL's header/invite to version 0.16.0.