### PR TITLE
Add link to FAQ page managed by elm-community.

### DIFF
--- a/src/pages/docs.elm
+++ b/src/pages/docs.elm
@@ -33,6 +33,7 @@ quickStart = """
   * [Make an HTML app](https://github.com/evancz/start-app)
   * [The Elm Architecture](https://github.com/evancz/elm-architecture-tutorial/)
   * [TodoMVC](https://github.com/evancz/elm-todomvc)
+  * [FAQ](http://elm-community.github.io/elm-faq/)
 
 ### References
 


### PR DESCRIPTION
Per suggestion in https://github.com/elm-lang/elm-lang.org/issues/510 I have modified the Documents page to add a link to the elm-community FAQ page.

The modified version can be seen in operation here: http://elm-lang.fantods.com/docs