### PR TITLE
Add explicit module (..) where syntax documentation

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -322,6 +322,9 @@ You can use as many commas as you want.
 ```elm
 module MyModule where
 
+-- module decleration exporting only foo and bar
+module MyModule (foo, bar) where
+
 -- qualified imports
 import List                    -- List.map, List.foldl
 import List as L               -- L.map, L.foldl


### PR DESCRIPTION
This commit adds documentation around exporting only specific functions from a module.
A co-worker said he had to read other people's code to figure that out. 
It should be part of the official syntax documentation.