### PR TITLE
Add mention about significant whitespace

### DIFF
--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -107,7 +107,7 @@ Now let's make a function that tells us if a number is over 9000.
 "It's over 9000!!!"
 ```
 
-Using a backslash in the REPL lets us split things on to multiple lines. We use this in the definition of `over9000` above. Furthermore, it is best practice to always bring the body of a function down a line. It makes things a lot more uniform and easy to read, so you want to do this with all the functions and values you define in normal code.
+Using a backslash in the REPL lets us split things on to multiple lines. We use this in the definition of `over9000` above. Furthermore, Elm uses significant whitespace, and it is mandatory to indent function body. It makes things a lot more uniform and easy to read, so you want to do this with all the functions and values you define in normal code.
 
 
 ## Lists


### PR DESCRIPTION
While learning Elm I found it confusing that the documentation A) said indenting function body is best-practice and B) didn't mention anything about significant whitespace. Clearly it is not best-practice, but mandatory.

```
> over9000 powerLevel = \
| if powerLevel > 9000 then "It's over 9000!!!" else "meh"
-- SYNTAX PROBLEM -------------------------------------------- repl-temp-000.elm

I ran into something unexpected when parsing your code!

3│   over9000 powerLevel =
                         ^
I am looking for one of the following things:

    end of input
    whitespace

```