### PR TITLE
Correct claim on docs page

### DIFF
--- a/src/pages/docs.elm
+++ b/src/pages/docs.elm
@@ -50,9 +50,8 @@ advancedStuff = """
 
 # Advanced Topics
 
-  * [Extensible Records][ext] &mdash; A full overview of how records work in Elm.
-    Gets into details of Daan Leijen's [paper][daan] that first described this
-    design.
+  * [Extensible Records][ext] &mdash; A full overview of how records work in Elm,
+    based on the design from a [paper][daan] by Daan Leijen.
 
   * [Taxonomy of FRP][taxonomy] &mdash; A talk that outlines the many flavors
     of FRP. It describes how they work, how they relate to each other, and how


### PR DESCRIPTION
The previous text claimed that the linked to page (http://elm-lang.org/docs/records) gets into details of Daan Leijen's paper. But that's not true. (The paper isn't even mentioned there, and in any case no details from the paper are discussed at all.)

Maybe it was true at some point, when the linked to page was different itself. But now all technical detail is absent, so what the linking sentence says is wrong. This PR corrects it into something that is true.