### PR TITLE
Add default message to enter password before user input

### DIFF
--- a/src/examples/sign-up.elm
+++ b/src/examples/sign-up.elm
@@ -51,7 +51,9 @@ view : Address Action -> Model -> Html
 view address model =
   let
     validationMessage =
-      if model.password == model.passwordAgain then
+      if model.password == "" && model.passwordAgain == "" then
+        span [style [("color", "orange")]] [text "Please enter a password"]
+      else if model.password == model.passwordAgain then
         span [style [("color", "green")]] [text "Passwords Match!"]
       else
         span [style [("color", "red")]] [text "Passwords do not match :("]


### PR DESCRIPTION
I may be off base here, and it may not be worth the add, but my initial thought when viewing this example was that having the passwords match (and display a positive "The passwords match!" notification) before typing in a password was a weird user experience, even for an example. This is my first PR for anything Elm-related, so if there are better ways to do this (regardless of whether this PR is merged), I'd love to know.