### PR TITLE
Add interop initial value example

### DIFF
--- a/src/guide/chapters/interop.md
+++ b/src/guide/chapters/interop.md
@@ -28,7 +28,7 @@ Elm.embed(Elm.Stamper, div);
 
 The `Elm.embed` function takes two arguments:
 
-  1. An Elm module. All modules are prefixed with `Elm` in JavaScript to avoid namespace pollution, so our `Stamper` module becomes `Elm.Stamper`. 
+  1. An Elm module. All modules are prefixed with `Elm` in JavaScript to avoid namespace pollution, so our `Stamper` module becomes `Elm.Stamper`.
   2. A `<div>` to embed the program in.
 
 That's it!
@@ -85,6 +85,16 @@ myapp.ports.addUser.send([
 
 This sends two updates to Elm, automatically converting to values that work well in Elm.
 
+
+### Initial Value
+
+When using a port, you must provide an initial value.
+
+```javascript
+Elm.fullscreen(Elm.Stamper, {
+  addUser: ["", {}]
+});
+```
 
 ### From Elm to JavaScript
 


### PR DESCRIPTION
## Description

When using a port in elm it is not easy to find the documentation around initial values.

## Elm Error
```
Port Error:

    No argument was given for the port named 'echo' with type:
    
        String
    
    You need to provide an initial value!
    
    Find out more about ports here <http://elm-lang.org/learn/Ports.elm>

Open the developer console for more details.
```

## Problem

The document linked does not have an example of using initial values.
[syntax#javascript-ffi](http://elm-lang.org/docs/syntax#javascript-ffi) has the example of initial value.

## Solution

Add an example for initial values to the interop page.