### PR TITLE
move built-in port handler example to interop

### DIFF
--- a/src/guide/chapters/interop.md
+++ b/src/guide/chapters/interop.md
@@ -133,3 +133,18 @@ The particular types that can be sent in and out of ports is quite flexible, cov
   * **Json**    &ndash; [`Json.Encode.Value`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Encode#Value) corresponds to arbitrary JSON
 
 All conversions are symmetric and type safe. If someone tries to give a badly typed value to Elm it will throw an error in JS immediately. By having a border check like this, Elm code can continue to guarantee that you will never have type errors at runtime.
+
+### Built-in Port Handlers
+
+Elm has some built-in port handlers that automatically take some
+imperative action:
+
+ * `title` sets the page title, ignoring empty strings
+ * `log` logs messages to the developer console
+ * `redirect` redirects to a different page, ignoring empty strings
+
+Experimental port handlers:
+
+ * `favicon` sets the pages favicon
+ * `stdout` logs to stdout in node.js and to console in browser
+ * `stderr` logs to stderr in node.js and to console in browser

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -408,17 +408,6 @@ More example uses can be found
 [here](https://github.com/evancz/elm-html-and-js)
 and [here](https://gist.github.com/evancz/8521339).
 
-Elm has some built-in port handlers that automatically take some
-imperative action:
-
- * `title` sets the page title, ignoring empty strings
- * `log` logs messages to the developer console
- * `redirect` redirects to a different page, ignoring empty strings
-
-Experimental port handlers:
-
- * `favicon` sets the pages favicon
- * `stdout` logs to stdout in node.js and to console in browser
- * `stderr` logs to stderr in node.js and to console in browser
+Elm has some built-in port handlers that are documented on the [interop](/guide/interop) page.
 
 """


### PR DESCRIPTION
## Description

The interop example does not describe built-in port handlers as described in #541. Rather than duplicating the example, I think it makes sense to move this example to interop and reference it from syntax since it isn't directly syntax related.