### PR TITLE
Updated documentation for records

### DIFF
--- a/src/pages/docs/records.elm
+++ b/src/pages/docs/records.elm
@@ -38,6 +38,7 @@ The structure of the following document is as follows:
 Records in Elm are quite similar to objects in JavaScript. The major differences
 are that with records:
 
+- You can not add or remove a field dynamically
 - You cannot ask for a field that does not exist.
 - No field will ever be `undefined` or `null`.
 - You cannot create recursive records with a `this` or `self` keyword.
@@ -248,8 +249,13 @@ hypotenuse {x,y} =
   sqrt (x^2 + y^2)
 ```
 
-You can also define extensible records. This use has not come up much in
-practice so far, but it is pretty cool nonetheless.
+It is also possible to use type aliases as constructors for records.
+
+```elm
+  Point 0 0
+```
+
+You can define extensible records with the folowing type alias synthax:
 
 ```elm
 type alias Positioned a =
@@ -261,6 +267,9 @@ type alias Named a =
 type alias Moving a =
   { a | velocity : Float, angle : Float }
 ```
+
+Type aliases for extensible records cannot be used as a constructor for a
+new record.
 
 This syntax is defining types that have *at least* certain fields, but may have
 others as well. So `Positioned a` is a record with at least an `x` and `y`


### PR DESCRIPTION
Updated documentation for records (Issue #529)

Mentioned, that type aliases can be used as constructors.

Clarified that type aliases for extensible records cannot be used as constructors.

Pointed out that you cannot add or remove fields in Records. 
