### PR TITLE
Added mention of indentation to core-language.md

### DIFF
--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -109,6 +109,8 @@ Now let's make a function that tells us if a number is over 9000.
 
 Using a backslash in the REPL lets us split things on to multiple lines. We use this in the definition of `over9000` above. Furthermore, it is best practice to always bring the body of a function down a line. It makes things a lot more uniform and easy to read, so you want to do this with all the functions and values you define in normal code.
 
+Note also that the second line of the definition for over9000 is indented. In functions as well as some other places, Elm is indentation-sensitive: it uses indentation to demark scope where another language might use curly brackets or do-end tokens.
+
 
 ## Lists
 


### PR DESCRIPTION
Added 2 sentences in the Functions section. There was some confusion as expressed in issue 79 and 81 of the elm-repl repo. I thought that this would help, as there is no other mention of indentation on this page.