### PR TITLE
Fix link for making-pong

### DIFF
--- a/src/examples/pong.elm
+++ b/src/examples/pong.elm
@@ -1,5 +1,5 @@
 -- See this document for more information on making Pong:
--- http://elm-lang.org/blog/pong
+-- http://elm-lang.org/blog/making-pong
 import Color exposing (..)
 import Graphics.Collage exposing (..)
 import Graphics.Element exposing (..)


### PR DESCRIPTION
The link to blog post about making pong was wrong. http://elm-lang.org/blog/making-pong