### PR TITLE
 Use HTML <label> tag

### DIFF
--- a/src/examples/radio-buttons.elm
+++ b/src/examples/radio-buttons.elm
@@ -1,4 +1,4 @@
-import Html exposing (Html, Attribute, div, input, span, text)
+import Html exposing (Html, Attribute, div, input, label, span, text)
 import Html.App exposing (beginnerProgram)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onCheck)
@@ -74,7 +74,7 @@ radio style name model =
     isSelected =
       model.style == style
   in
-    div []
+    label []
       [ input [ type' "radio", checked isSelected, onCheck (\_ -> Switch style) ] []
       , text name
       ]


### PR DESCRIPTION
The label of a radio button should be in a `<label>` element, and not in a `<div>`, according to the HTML specification.