### PR TITLE
Fixed url (ws://echo.websocket.org)

### DIFF
--- a/src/examples/websockets.elm
+++ b/src/examples/websockets.elm
@@ -17,7 +17,7 @@ main =
 
 echoServer : String
 echoServer =
-  "ws://echo.websocket.org"
+  "wss://echo.websocket.org"
 
 
 


### PR DESCRIPTION
Changed _ws://echo.websocket.org_ to _wss://echo.websocket.org_ because the former doesn't work.