### PR TITLE
Some explanation of why let expressions are necessary

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -242,7 +242,7 @@ are function composition operators.
 ### Let Expressions
 
 Let expressions are for assigning variables, kind of like a `var` in
-JavaScript.
+JavaScript. Only the expression after `in` is returned.
 
 ```elm
 let


### PR DESCRIPTION
I remember being confused about what they were doing and why they were necessary. I guess the best way to introduce them would be for an expression to become too complicated to read and understand that it was good to break it out into `let` ... `in`. You could argue that I should already get this principle from e.g. programming in JavaScript, but what if Elm was my first language?
