### PR TITLE
Fix link to Sublime Text editor plugin

### DIFF
--- a/src/pages/get-started.elm
+++ b/src/pages/get-started.elm
@@ -140,7 +140,7 @@ We know of Elm syntax highlighting modes for at least the following text editors
   * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
   * [Light Table](https://github.com/rundis/elm-light)
-  * [Sublime Text](https://github.com/deadfoxygrandpa/Elm.tmLanguage)
+  * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/lambdatoast/elm.vim)
   * [VS Code](https://github.com/sbrink/vscode-elm)
 


### PR DESCRIPTION
Current link points to a defunct GitHub repo.

This updates it to point to the official Sublime Text Package page instead, which is both non-defunct and a more direct route to obtaining the package.