### PR TITLE
Correct sample syntax

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -274,7 +274,7 @@ the one above it.
 
 Finally, you can add type annotations in let-expressions.
 
-```haskell
+```elm
 let
   name : String
   name =


### PR DESCRIPTION
`haskell` syntax results into un-styled piece of code.