### PR TITLE
Add IntelliJ syntax highlighting

### DIFF
--- a/src/pages/get-started.elm
+++ b/src/pages/get-started.elm
@@ -143,6 +143,7 @@ We know of Elm syntax highlighting modes for at least the following text editors
   * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/lambdatoast/elm.vim)
   * [VS Code](https://github.com/sbrink/vscode-elm)
+  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
 
 There may be others out there. If you cannot find an Elm mode for your
 favorite editor, using Haskell syntax highlighting is close enough to be

--- a/src/pages/get-started.elm
+++ b/src/pages/get-started.elm
@@ -139,11 +139,11 @@ We know of Elm syntax highlighting modes for at least the following text editors
   * [Atom](https://atom.io/packages/language-elm)
   * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
+  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
   * [Light Table](https://github.com/rundis/elm-light)
   * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/lambdatoast/elm.vim)
   * [VS Code](https://github.com/sbrink/vscode-elm)
-  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
 
 There may be others out there. If you cannot find an Elm mode for your
 favorite editor, using Haskell syntax highlighting is close enough to be

--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -31,11 +31,11 @@ Afterwards, visit the [get started page][get-started].
   * [Atom](https://atom.io/packages/language-elm)
   * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
+  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
   * [Light Table](https://github.com/rundis/elm-light)
   * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/lambdatoast/elm.vim)
   * [VS Code](https://github.com/sbrink/vscode-elm)
-  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
 
 
 ## Help

--- a/src/pages/install.elm
+++ b/src/pages/install.elm
@@ -35,6 +35,7 @@ Afterwards, visit the [get started page][get-started].
   * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/lambdatoast/elm.vim)
   * [VS Code](https://github.com/sbrink/vscode-elm)
+  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
 
 
 ## Help


### PR DESCRIPTION
Now it's in alphabetical order.