### PR TITLE
use https for GETting giphy url so example works in Firefox

### DIFF
--- a/src/examples/http.elm
+++ b/src/examples/http.elm
@@ -88,7 +88,7 @@ getRandomGif : String -> Cmd Msg
 getRandomGif topic =
   let
     url =
-      "http://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
+      "https://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
   in
     Task.perform FetchFail FetchSucceed (Http.get decodeGifUrl url)
 


### PR DESCRIPTION
Giphy has CORS enabled which means images will fail to load in at least Firefox. Simply making sure the URL uses https (good practice) fixes this example :)