### PR TITLE
Update REPL exit instructions

### DIFF
--- a/src/pages/blog/announce/repl.elm
+++ b/src/pages/blog/announce/repl.elm
@@ -39,7 +39,7 @@ please get in contact with the authors. This is a great way to contribute to Elm
 ## Usage
 
 The first thing to know about a REPL is how to exit:
-press `Ctrl-c` twice.
+press `Ctrl-d`.
 
 When you enter an expression, you get the result and its type:
 


### PR DESCRIPTION
When you Google "elm quit repl", [this page](http://elm-lang.org/blog/announce/repl) comes up first. I understand the blog was posted years ago, so this is rewriting history. But this would be really helpful for newbies. :)