### PR TITLE
Adds the missing Get-Started link to docs

### DIFF
--- a/src/pages/docs.elm
+++ b/src/pages/docs.elm
@@ -28,6 +28,7 @@ content = """
 ### References
 
   * **[The Guide](http://guide.elm-lang.org)**
+  * [Get started](/get-started)
   * [Syntax](/docs/syntax)
   * [Syntax vs JS](/docs/from-javascript)
   * [Style Guide](/docs/style-guide)


### PR DESCRIPTION
As discussed in issue #557 this is missing from the docs page. Not certain where to put it, but located under references now, should possibly be under "Quick overview".

I think this is very important to new developers coming into Elm.