### PR TITLE
Fix incorrect usage of topic field

### DIFF
--- a/src/examples/http.elm
+++ b/src/examples/http.elm
@@ -29,7 +29,7 @@ type alias Model =
 
 init : String -> (Model, Cmd Msg)
 init topic =
-  ( Model topic "waiting.gif"
+  ( Model topic "cats"
   , getRandomGif topic
   )
 
@@ -51,7 +51,7 @@ update msg model =
       (model, getRandomGif model.topic)
 
     FetchSucceed newUrl ->
-      (Model model.topic newUrl, Cmd.none)
+      (Model model.gifUrl newUrl, Cmd.none)
 
     FetchFail _ ->
       (model, Cmd.none)


### PR DESCRIPTION
The example was using the `topic` field as the `gifUrl` field.  Fixed to set the initial value of topic to `cats` and use the `gifUrl` field when updating the model after FetchSucceed