### PR TITLE
Link to sketch-n-sketch that works in Chrome

### DIFF
--- a/src/pages/home.elm
+++ b/src/pages/home.elm
@@ -174,7 +174,7 @@ examples =
       "https://github.com/w0rm/elm-flatris"
   , example
       "sketch-n-sketch"
-      "http://ravichugh.github.io/sketch-n-sketch/releases/latest/"
+      "http://ravichugh.github.io/sketch-n-sketch/releases/v0.5/"
       "https://github.com/ravichugh/sketch-n-sketch"
   ]
 


### PR DESCRIPTION
Addresses https://github.com/elm-lang/elm-lang.org/issues/638 by linking to a slightly older version that works in Chrome.