### PR TITLE
Workaround for elm-markdown mis-parsing urls

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -235,7 +235,7 @@ viewNames2 names =
 Historical note: this is borrowed from F#, inspired by Unix pipes.
 
 Relatedly, [`(<<)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#<<)
-and [`(>>)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#>>)
+and [`(>>)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#>>>)
 are function composition operators.
 
 


### PR DESCRIPTION
Workaround for elm-markdown mis-parsing urls with `>`.  This should be corrected once/if elm-markdown is corrected.