### PR TITLE
Fix List.range typo

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -195,7 +195,7 @@ square =
   \\n -> n^2
 
 squares =
-  List.map (\\n -> n^2) (List.rang 1 100)
+  List.map (\\n -> n^2) (List.range 1 100)
 ```
 
 ### Infix Operators


### PR DESCRIPTION
Fixes List.range typo in syntax docs.