### PR TITLE
Make more elm-lang packages available on Try

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,12 +9,15 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/keyboard": "1.0.1 <= v < 2.0.0",
         "elm-lang/mouse": "1.0.1 <= v < 2.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
+        "elm-lang/window": "1.0.1 <= v < 2.0.0",
         "evancz/elm-markdown": "3.0.1 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
It's common for introductory Elm material to have examples that use these packages which are not currently available through Try:

 - elm-lang/animation-frame
 - elm-lang/keyboard
 - elm-lang/window

It may be worth also adding the following, but I felt they weren't as popular for intro examples as the three listed above and so are not included in this PR:

  - elm-lang/navigation
  - elm-lang/page-visibility
  - elm-lang/geolocation