### PR TITLE
edited comment for pipes example

### DIFF
--- a/src/examples/pipes.elm
+++ b/src/examples/pipes.elm
@@ -21,7 +21,7 @@ exact function in a different way.
 
 Think of the pipe as feeding a value into the next function. In
 this case, we feed the string into reverse, then into toUpper,
-then we filter out any numbers.
+then we filter out any whitespaces.
 -}
 weirdReversal2 string =
   string


### PR DESCRIPTION
whitespaces, not numbers are being removed from the string in the last
step, before it gets returned