### PR TITLE
Fix outdated range syntax in documentation

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -362,7 +362,7 @@ answer =
 
 factorial : Int -> Int
 factorial n =
-  List.product [1..n]
+  List.product (List.range 1 n)
 
 distance : { x : Float, y : Float } -> Float
 distance {x,y} =


### PR DESCRIPTION
This example of the old range syntax is still up at [elm-lang.org/docs/syntax](http://elm-lang.org/docs/syntax), it won't compile under current versions and has thrown at least one user on Stack Overflow.