### PR TITLE
Remove dead link : Escape from callback hell

### DIFF
--- a/src/backend/Router.hs
+++ b/src/backend/Router.hs
@@ -154,7 +154,6 @@ redirects =
     , "blog/announce/Repl.elm" ==> "/blog/announce/repl"
     , "blog/Interactive-Programming.elm" ==> "/blog/interactive-programming"
     , "blog/announce/Elm-and-Prezi.elm" ==> "/blog/announce/elm-and-prezi"
-    , "learn/Escape-from-Callback-Hell.elm" ==> "/learn/escape-from-callback-hell"
     , "blog/Pong.elm" ==> "/blog/making-pong"
     , "learn/Syntax.elm" ==> "/docs/syntax"
     , "learn/FAQ.elm" ==> "/docs/from-javascript"

--- a/src/pages/blog.elm
+++ b/src/pages/blog.elm
@@ -31,7 +31,6 @@ blog = """
  * [Concepts behind the Elm Logo](https://prezi.com/npjjrmt_badc/tangrams-logo/)
  * [Elm in VentureBeat](http://venturebeat.com/2013/07/26/why-i-designed-a-front-end-programming-language-from-scratch/)
  * [Elm &hearts; Prezi](/blog/announce/elm-and-prezi)
- * [Escape from Callback Hell](/blog/escape-from-callback-hell)
  * [Making Pong](/blog/making-pong)
 
 <br>


### PR DESCRIPTION
The article was removed. The link is still existing but dead. It should be removed.

### Dead link
http://elm-lang.org/blog/escape-from-callback-hell

### Issues
Mentioned in issues #666, #550 and #450 .