### PR TITLE
Add reference to GameSkeleton that exists

### DIFF
--- a/src/pages/blog/making-pong.elm
+++ b/src/pages/blog/making-pong.elm
@@ -83,7 +83,7 @@ skeleton for game creation][skeleton] which can both be a starting point for
 playing around with your own ideas.
 
  [src]: /examples/pong
- [skeleton]: https://github.com/elm-lang/elm-lang.org/blob/master/frontend/public/examples/Intermediate/GameSkeleton.elm
+ [skeleton]: https://github.com/thomasbhatia/Elm/blob/master/Examples/elm-js/GameSkeleton/GameSkeleton.elm
 
 Let&rsquo;s get into the code!
 


### PR DESCRIPTION
Not saying this is the correct solution in terms of where the reference
lives, the game skeleton should probably live in it's own repo hosted by
elm-lang or just not be in the blog post at all if this no longer exists.

:) Thank you!