### PR TITLE
Clarify writing in 'Declarations' section 

### DIFF
--- a/src/pages/docs/style-guide.elm
+++ b/src/pages/docs/style-guide.elm
@@ -88,9 +88,10 @@ We saved vertical lines here, but at the cost of regularity and ease of
 modification. If `Literal` ever becomes longer, all arrows must move. If any
 branch gets too long, everything needs to come down a line anyway.
 
-Having `case` appear further to the right than the actual cases is strongly discouraged. It
-should serve as a context clue that makes glancing through code easy, but when
-indented or positioned in crazy ways, it becomes more difficult to glance through.
+Having `case` appear further to the right than the actual cases is strongly
+discouraged. It should serve as a context clue that makes glancing through code
+easy, but when indented or positioned in crazy ways, it becomes more difficult
+to glance through.
 
 
 ## Types

--- a/src/pages/docs/style-guide.elm
+++ b/src/pages/docs/style-guide.elm
@@ -88,9 +88,9 @@ We saved vertical lines here, but at the cost of regularity and ease of
 modification. If `Literal` ever becomes longer, all arrows must move. If any
 branch gets too long, everything needs to come down a line anyway.
 
-Having `case` appear *later* than the actual cases is strongly discouraged. It
+Having `case` appear further to the right than the actual cases is strongly discouraged. It
 should serve as a context clue that makes glancing through code easy, but when
-indented in crazy ways, it becomes more difficult to glance through.
+indented or positioned in crazy ways, it becomes more difficult to glance through.
 
 
 ## Types

--- a/src/pages/docs/style-guide.elm
+++ b/src/pages/docs/style-guide.elm
@@ -77,7 +77,7 @@ the result will still look quite nice.
 ```elm
 homeDirectory = "/root/files"
 
-eval boolean = case boolean of
+evaluate boolean = case boolean of
     Literal bool -> bool
     Not b        -> not (eval b)
     And b b_     -> eval b && eval b_


### PR DESCRIPTION
This series replaces 'later' with 'to the right of', mentions "indenting or positioning" for clarity, and corrects the name of the `evaluate` function in the "bad" example to match the function name in the "good" example.
