### PR TITLE
Different variable names from type variables

### DIFF
--- a/src/examples/either.elm
+++ b/src/examples/either.elm
@@ -27,19 +27,19 @@ partition eithers =
     [] ->
       ([], [])
 
-    Left a :: rest ->
+    Left leftPayload :: rest ->
       let
         (lefts, rights) =
           partition rest
       in
-        (a :: lefts, rights)
+        (leftPayload :: lefts, rights)
 
-    Right b :: rest ->
+    Right rightPayload :: rest ->
       let
         (lefts, rights) =
           partition rest
       in
-        (lefts, b :: rights)
+        (lefts, rightPayload :: rights)
 
 
 main =


### PR DESCRIPTION
I am writing a small ELM beginners guide. I am at the part of explaining pattern matching. While trying to explain this example, I feel that some people might confuse `a` and `b` from the type signature (`Either a b`) with this `a` and `b` from the pattern matches. I tried to come up with a more descriptive name, just to avoid an unnecessary clash.