### PR TITLE
Add link to companion blog post

### DIFF
--- a/src/pages/blog/how-to-use-elm-at-work.elm
+++ b/src/pages/blog/how-to-use-elm-at-work.elm
@@ -86,6 +86,8 @@ The previous sections give you a flavor of what to do, but I wanted to make a ch
 
   - **Write Elm Code** &mdash; You can talk a decision like this to death. What about this? What about that? Talking abstractly is a waste of everyone&rsquo;s time. Write an actual chunk of Elm code. Evaluate it against an actual chunk of JavaScript code. Talk concretely.
 
+Please see the companion blog post ["Using Elm in React — from the ground up"](https://medium.com/@cuddlyburger/using-elm-in-react-from-the-ground-up-e3866bb0369d), for a detailed, step by step walkthrough of the technical details.
+
 Hopefully that helps you out! I would love to hear how it goes, so definitely share your story as a blog post or through one of [the community forums](http://elm-lang.org/community). The community is really friendly and will definitely benefit from your experience, whether it works out or not. And who knows, maybe we can help out in some way!
 
 


### PR DESCRIPTION
I tried to add an elm component in to a React project, and found it surprisingly difficult (I almost gave up), due to a variety of small niggles. Generally, when I find something difficult and there isn't good help on the internet, I tend to write a blog post about it.

This commit adds a link to a blog post that has detailed step by step instructions, alongside a GitHub repo with corresponding commits. I hope that following this blog post will turn what was for me a long job of exploration in to a quick and easy job.