### PR TITLE
Fix drag and drop example

### DIFF
--- a/src/examples/drag.elm
+++ b/src/examples/drag.elm
@@ -107,6 +107,8 @@ view model =
           , "display" => "flex"
           , "align-items" => "center"
           , "justify-content" => "center"
+          , "user-select" => "none"
+          , "-moz-user-select" => "none"
           ]
       ]
       [ text "Drag Me!"


### PR DESCRIPTION
This makes the text in the draggable box non-selectable,
which prevents issue with dragged box not being released
in the rare cases when you inadvertently select the text in the box
and then start dragging by clicking within the selected text.
In such case dragging is not stopped by releasing mouse button and
the example looks broken.

The issue was discussed here: https://groups.google.com/forum/#!topic/elm-discuss/AMKmMRvTDLs