### PR TITLE
Add Discourse, deprecate elm-discuss

### DIFF
--- a/src/pages/community.elm
+++ b/src/pages/community.elm
@@ -90,15 +90,13 @@ the Elm user group in SF. A lot of existing meetups are structured based on
 [hack-night]: http://tech.noredink.com/post/142283641812/designing-meetups-to-build-better-communities
 
 
-## Mailing list
+## Historical: Mailing list
 
 [list]: https://groups.google.com/forum/?fromgroups#!forum/elm-discuss "elm-discuss"
 
-The [elm-discuss][list] mailing list is the original online forum for Elm. We
+The [elm-discuss][list] mailing list was the original online forum for Elm. We
 used to do all discussion there, from beginner questions to language design
-discussions. These days it is in between [/r/elm](https://www.reddit.com/r/elm/)
-and [elm-dev](https://groups.google.com/d/msg/elm-dev/oZ3xW_nMPNo/0y8j-N8HCQAJ).
-There are some people (and their expertise) only available through email!
+discussions. As of January 2018, it has been replaced by [Discourse][discourse].
 
 
 ## Contribute

--- a/src/pages/community.elm
+++ b/src/pages/community.elm
@@ -15,6 +15,7 @@ community = """
 # Community
 
   * [Community Packages](http://package.elm-lang.org/)
+  * [Discourse][discourse]
   * [Reddit][reddit]
   * [Slack][slack]
   * [Twitter][twitter]
@@ -23,6 +24,15 @@ community = """
   * [Contributing](#contribute)
 
 <br>
+
+
+## Discourse
+
+[discourse]: https://discourse.elm-lang.org/ "Discourse"
+
+[Discourse][discourse] is a nice place to ask questions, request
+feedback on your ideas, and show off what you're working on. It is the
+successor to [elm-discuss on Google Groups][list].
 
 
 ## Reddit


### PR DESCRIPTION
This PR adds Discourse to the community page, and deprecates elm-discuss (but leaves the link up for historical reasons.)

I'm fine with going with this as-is, but have a few more thoughts… something about this page feels disjointed to me. I think it may be because there is a lot of good advice on the page that seems directed toward one forum but which is applicable everywhere. Example: Reddit being helpful but watch out for displacement.

I don't want to make big changes without talking about it first, but I think it might work better to organize the fora by intent, the way we do categories on Discourse:

```
# Community

All the links at the top as now.

## Learn

Blurb about XY problem.

Focus of links: getting beginners connected with the community quickly.

- Real life
- Slack (#general, #beginners)
- Discourse (Learn)
- Reddit

## Collaborate

Blurb about contributing.

Focus of links: pointing people to the right places to deepen their involvement in the language ecosystem.

- Real life
- Slack (focus-specific channels)
- Discourse (Learn, Request Feedback)
- Mailing lists (mostly for finding context on older discussions, but maybe add elm-dev?)

Blurb about displacement.

## Share

New blurb along the lines of "communication is collaboration".
Encourage people to work openly, and that sharing is best when that's already happened.

Focus of links: getting cool stuff in front of as many people as possible.

- Twitter
- Slack (#news-and-links)
- Discourse (Show and Tell)
- Reddit
- Package site
```

Does that make sense? If it sounds good, I'll make these changes as part of this PR.