### PR TITLE
Update Flatris url

### DIFF
--- a/src/pages/home.elm
+++ b/src/pages/home.elm
@@ -171,7 +171,7 @@ examples =
       "https://github.com/elm-lang/package.elm-lang.org"
   , example
       "flatris"
-      "http://unsoundscapes.com/elm-flatris.html"
+      "https://unsoundscapes.itch.io/flatris"
       "https://github.com/w0rm/elm-flatris"
   , example
       "sketch-n-sketch"


### PR DESCRIPTION
I host all my games on [itch.io](https://itch.io), so I've moved [Flatris](https://unsoundscapes.itch.io/flatris) there too. In fact, it is configured now to [automatically deploy to itch.io](https://github.com/w0rm/elm-flatris/pull/22).

While doing this, I updated the Flatris code to [not use Native](https://github.com/w0rm/elm-flatris/pull/21). Flatris now uses ports to persist the game state in the `localStorage`.